### PR TITLE
Improve Persian PDF rendering

### DIFF
--- a/core/requirements.txt
+++ b/core/requirements.txt
@@ -75,3 +75,5 @@ vine==5.1.0
 wcwidth==0.2.13
 python-docx
 reportlab
+arabic-reshaper
+python-bidi


### PR DESCRIPTION
## Summary
- add bidi and Arabic reshaping helpers to render Persian text correctly in exported PDFs
- reuse registered fonts and apply RTL-aware wrapping for PDF generation
- include arabic-reshaper and python-bidi dependencies

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692889dacacc8327a03b245e2eec6d63)