### PR TITLE
Adjust dashboard scrolling and export formatting

### DIFF
--- a/core/main/api/v1/serializers.py
+++ b/core/main/api/v1/serializers.py
@@ -9,12 +9,13 @@ class AudioListItemSerializer(serializers.ModelSerializer):
     uploaded_at = serializers.DateTimeField(source='created_at', read_only=True)
     file_type_display = serializers.SerializerMethodField()
     status_display = serializers.SerializerMethodField()
+    uploader = serializers.SerializerMethodField()
 
     class Meta:
         model = Audio
         fields = [
             'id', 'file_name', 'uploaded_at', 'file_type', 'file_type_display',
-            'status', 'status_display', 'subset_title', 'upload_uuid', 'task_id'
+            'status', 'status_display', 'subset_title', 'upload_uuid', 'task_id', 'uploader'
         ]
         read_only_fields = fields
 
@@ -50,3 +51,16 @@ class AudioListItemSerializer(serializers.ModelSerializer):
             str: Display label of the current processing status.
         """
         return obj.get_status_display()
+
+    def get_uploader(self, obj):
+        """Return the full name of the uploader profile if available."""
+
+        profile = getattr(obj, 'user_uplouder', None)
+        if not profile:
+            return ''
+
+        name = getattr(profile, 'name', '') or ''
+        family = getattr(profile, 'family', '') or ''
+
+        full_name = f"{name} {family}".strip()
+        return full_name or ''

--- a/core/main/api/v1/views.py
+++ b/core/main/api/v1/views.py
@@ -20,7 +20,7 @@ class AudioListView(generics.ListAPIView):
 
     def get_queryset(self):
         """Return the ordered queryset with subset relationship eagerly loaded."""
-        return Audio.objects.select_related('subset').order_by('-created_at')
+        return Audio.objects.select_related('subset', 'user_uplouder').order_by('-created_at')
 
     def list(self, request, *args, **kwargs):
         """Return paginated audio items along with aggregate counts.

--- a/core/office/api/v1/views.py
+++ b/core/office/api/v1/views.py
@@ -200,12 +200,12 @@ class ExportCustomContentZipView(APIView):
         document = Document()
 
         def _apply_paragraph_rtl(paragraph):
-            """Ensure paragraphs are right-aligned and marked as RTL when supported."""
+            """Ensure paragraphs are left-aligned while keeping RTL glyph shaping."""
 
             if WD_PARAGRAPH_ALIGNMENT is not None:
-                paragraph.alignment = WD_PARAGRAPH_ALIGNMENT.RIGHT
+                paragraph.alignment = WD_PARAGRAPH_ALIGNMENT.LEFT
             try:
-                paragraph.paragraph_format.rtl = True
+                paragraph.paragraph_format.rtl = False
             except Exception:
                 pass
 
@@ -236,13 +236,13 @@ class ExportCustomContentZipView(APIView):
                 pass
 
         def _apply_document_rtl_defaults():
-            """Set document-level RTL hints and default RTL alignment for new paragraphs."""
+            """Set document-level defaults to left alignment while keeping Vazirmatn font."""
 
             if WD_PARAGRAPH_ALIGNMENT is not None:
                 try:
                     normal_style = document.styles['Normal']
-                    normal_style.paragraph_format.alignment = WD_PARAGRAPH_ALIGNMENT.RIGHT
-                    normal_style.paragraph_format.rtl = True
+                    normal_style.paragraph_format.alignment = WD_PARAGRAPH_ALIGNMENT.LEFT
+                    normal_style.paragraph_format.rtl = False
                 except Exception:
                     pass
 
@@ -316,6 +316,8 @@ class ExportCustomContentZipView(APIView):
             return None
 
         font_name = _register_persian_font()
+        if not font_name:
+            return Response({'detail': 'فونت وزیرمتن برای ساخت PDF در دسترس نیست.'}, status=500)
 
         def _prepare_rtl_text(text: str) -> str:
             """Return a display-ready RTL string when bidi helpers are available."""
@@ -346,7 +348,7 @@ class ExportCustomContentZipView(APIView):
         persian_style = ParagraphStyle(
             name="Persian",
             parent=base_styles["Normal"],
-            fontName=font_name or "Helvetica",
+            fontName=font_name,
             fontSize=12,
             leading=16,
             alignment=TA_RIGHT,

--- a/front/components/MainLayout.tsx
+++ b/front/components/MainLayout.tsx
@@ -12,7 +12,7 @@ const MainLayout: React.FC = () => {
     const [headerSearchTerm, setHeaderSearchTerm] = useState('');
 
     return (
-        <div className="relative min-h-screen overflow-x-hidden text-slate-100 animate-page">
+        <div className="relative min-h-screen overflow-x-hidden text-slate-100 animate-page-safe">
             <div className="pointer-events-none absolute -top-16 -left-10 h-72 w-72 rounded-full bg-gradient-to-br from-[#58bdf3]/60 via-[#3a64e0]/55 to-[#10244c]/55 blur-[120px] opacity-90" />
             <div className="pointer-events-none absolute -bottom-40 -right-10 h-96 w-96 rounded-full bg-gradient-to-tr from-[#101a33]/75 via-[#0c2344]/70 to-[#0e1730]/70 blur-[140px] opacity-80" />
             <div className="pointer-events-none absolute top-24 left-1/3 h-[22rem] w-[22rem] rounded-full bg-gradient-to-br from-[#8b5cf6]/45 via-[#14b8a6]/35 to-[#0ea5e9]/35 blur-[150px] opacity-80" />

--- a/front/contexts/FileContext.tsx
+++ b/front/contexts/FileContext.tsx
@@ -66,7 +66,7 @@ const convertApiFileToFileData = (apiFile: AudioFileItem): FileData => {
     progressLabel: statusDisplay,
     task_id: apiFile.task_id,
     upload_uuid: apiFile.upload_uuid,
-    uploader: (apiFile as any).uploader || undefined,
+    uploader: apiFile.uploader || undefined,
   } as FileData;
 };
 

--- a/front/index.html
+++ b/front/index.html
@@ -129,6 +129,11 @@
         100% { opacity: 1; transform: translateY(0); }
       }
 
+      @keyframes fadeInOpacity {
+        0% { opacity: 0; }
+        100% { opacity: 1; }
+      }
+
       @keyframes softPop {
         0% { opacity: 0; transform: scale(0.95); }
         60% { opacity: 1; transform: scale(1.02); }
@@ -179,6 +184,10 @@
 
       .animate-page {
         animation: fadeInUp 0.6s ease both;
+      }
+
+      .animate-page-safe {
+        animation: fadeInOpacity 0.6s ease both;
       }
 
       .animate-card {

--- a/front/pages/DashboardPage.tsx
+++ b/front/pages/DashboardPage.tsx
@@ -34,6 +34,10 @@ const DashboardPage: React.FC = () => {
     };
 
     useEffect(() => {
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+    }, []);
+
+    useEffect(() => {
         const state = locationState as { scrollToTop?: boolean } | null;
         if (!state?.scrollToTop) return;
 
@@ -435,7 +439,7 @@ const DashboardPage: React.FC = () => {
                                                     >
                                                         <td className="px-6 py-4 font-medium text-gray-900 whitespace-nowrap max-w-[170px]">
                                                             <div className="truncate" title={file.name}>{file.name}</div>
-                                                            <div className="text-xs text-slate-500 mt-1">{file.uploader ? `توسط ${file.uploader}` : 'بارگذاری شده'}</div>
+                                                            <div className="text-xs text-slate-500 mt-1">{`توسط ${file.uploader || 'ادمین'}`}</div>
                                                         </td>
                                                         <td className="px-6 py-4 align-top">
                                                             <div className="space-y-1 text-[13px] text-slate-700">

--- a/front/pages/DashboardPage.tsx
+++ b/front/pages/DashboardPage.tsx
@@ -290,24 +290,12 @@ const DashboardPage: React.FC = () => {
     useEffect(() => {
         if (!recentlyAddedFileId) return;
 
-        const listTop = listSectionRef.current?.getBoundingClientRect().top;
-        if (typeof listTop === 'number') {
-            const scrollTarget = window.scrollY + listTop - 40;
-            window.scrollTo({ top: Math.max(scrollTarget, 0), behavior: 'smooth' });
-        } else {
-            listSectionRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
-        }
-
+        window.scrollTo({ top: 0, behavior: 'smooth' });
         setHighlightedFileId(recentlyAddedFileId);
     }, [recentlyAddedFileId]);
 
     useEffect(() => {
         if (!highlightedFileId) return;
-
-        const scrollTimeout = window.setTimeout(() => {
-            const targetRow = rowRefs.current[highlightedFileId];
-            targetRow?.scrollIntoView({ behavior: 'smooth', block: 'start', inline: 'nearest' });
-        }, 100);
 
         const clearTimeoutId = window.setTimeout(() => {
             setHighlightedFileId(null);
@@ -315,10 +303,9 @@ const DashboardPage: React.FC = () => {
         }, 4000);
 
         return () => {
-            clearTimeout(scrollTimeout);
             clearTimeout(clearTimeoutId);
         };
-    }, [highlightedFileId, filteredFiles, clearRecentlyAddedFile]);
+    }, [highlightedFileId, clearRecentlyAddedFile]);
 
     if (loading) {
         return (

--- a/front/pages/DashboardPage.tsx
+++ b/front/pages/DashboardPage.tsx
@@ -397,14 +397,14 @@ const DashboardPage: React.FC = () => {
                         </div>
 
                         <div className="overflow-x-auto">
-                            <table className="w-full text-sm text-right text-gray-600">
+                            <table className="w-full min-w-[980px] text-sm text-right text-gray-600">
                                 <thead className="text-xs text-gray-700 uppercase bg-slate-50/80">
                                     <tr>
-                                        <th scope="col" className="px-6 py-3">نام فایل صوتی</th>
-                                        <th scope="col" className="px-6 py-3">تاریخ</th>
-                                        <th scope="col" className="px-6 py-3 hidden md:table-cell">نوع</th>
-                                        <th scope="col" className="px-6 py-3">وضعیت</th>
-                                        <th scope="col" className="px-6 py-3">اقدامات</th>
+                                        <th scope="col" className="px-6 py-3 min-w-[200px]">نام فایل صوتی</th>
+                                        <th scope="col" className="px-6 py-3 min-w-[170px]">تاریخ</th>
+                                        <th scope="col" className="px-6 py-3 hidden md:table-cell min-w-[120px]">نوع</th>
+                                        <th scope="col" className="px-6 py-3 min-w-[210px]">وضعیت</th>
+                                        <th scope="col" className="px-6 py-3 min-w-[220px]">اقدامات</th>
                                     </tr>
                                 </thead>
                                 <tbody>
@@ -437,7 +437,7 @@ const DashboardPage: React.FC = () => {
                                                         className={`bg-white border-b hover:bg-gray-50 table-row-animate transition-shadow duration-300 ${isHighlighted ? 'ring-2 ring-indigo-200 ring-offset-2 ring-offset-white bg-indigo-50/50 shadow-md new-row-highlight' : ''}`}
                                                         style={{ animationDelay: `${index * 45}ms` }}
                                                     >
-                                                        <td className="px-6 py-4 font-medium text-gray-900 whitespace-nowrap max-w-[170px]">
+                                                        <td className="px-6 py-4 font-medium text-gray-900 whitespace-nowrap max-w-[200px]">
                                                             <div className="truncate" title={file.name}>{file.name}</div>
                                                             <div className="text-xs text-slate-500 mt-1">{`توسط ${file.uploader || 'ادمین'}`}</div>
                                                         </td>
@@ -458,8 +458,8 @@ const DashboardPage: React.FC = () => {
                                                                 {file.type}
                                                             </span>
                                                         </td>
-                                                        <td className="px-6 py-4">
-                                                            <div className="space-y-2">
+                                                        <td className="px-6 py-4 align-top">
+                                                            <div className="space-y-2 max-w-[240px]">
                                                                 {renderStatusBadge(file.status)}
                                                                 {file.status === FileStatus.Processing && (
                                                                     <div className="space-y-1">
@@ -495,14 +495,14 @@ const DashboardPage: React.FC = () => {
                                                                 )}
                                                             </div>
                                                         </td>
-                                                        <td className="px-6 py-4">
-                                                            <div className="flex flex-col gap-2">
+                                                        <td className="px-6 py-4 align-top">
+                                                            <div className="flex flex-col gap-3 min-w-[220px]">
                                                                 {summary && (
-                                                                    <p className="text-xs text-slate-600 max-w-[280px] truncate" title={summary}>
+                                                                    <p className="text-xs text-slate-600 max-w-[320px] truncate" title={summary}>
                                                                         {summary}
                                                                     </p>
                                                                 )}
-                                                                <div className="flex items-center gap-x-2">
+                                                                <div className="flex flex-wrap items-center gap-2 justify-start">
                                                                     <button
                                                                         onClick={() => handleViewClick(file)}
                                                                         className="p-1.5 text-gray-500 hover:text-indigo-600 rounded-md hover:bg-gray-100 transition disabled:opacity-30 disabled:cursor-not-allowed"

--- a/front/types.ts
+++ b/front/types.ts
@@ -58,6 +58,7 @@ export interface AudioFileItem {
   subset_title: string;
   upload_uuid: string;
   task_id?: string | null;
+  uploader?: string;
 }
 
 export interface DashboardResponse {


### PR DESCRIPTION
## Summary
- scroll the dashboard to the top on load and show the uploader name in the audio file list
- left-align generated DOCX exports and require Vazirmatn as the PDF font

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931742a0c9c83278c2d5dbe0309db76)