### PR TITLE
Ensure audio file actions remain visible

### DIFF
--- a/front/pages/DashboardPage.tsx
+++ b/front/pages/DashboardPage.tsx
@@ -482,8 +482,8 @@ const DashboardPage: React.FC = () => {
                                                                 )}
                                                             </div>
                                                         </td>
-                                                        <td className="px-3 py-4 align-top w-[210px] max-w-[220px] sticky right-0 bg-white border-l border-slate-100 shadow-[inset_1px_0_0_rgba(226,232,240,1),0_6px_18px_rgba(15,23,42,0.06)] z-20">
-                                                            <div className="flex flex-col gap-3 min-w-[210px]">
+                                                        <td className="px-3 py-4 align-top w-[185px] max-w-[190px] sticky right-0 bg-white border-l border-slate-100 shadow-[inset_1px_0_0_rgba(226,232,240,1),0_6px_18px_rgba(15,23,42,0.06)] z-20">
+                                                            <div className="flex flex-col gap-3 min-w-[185px]">
                                                                 {summary && (
                                                                     <p className="text-xs text-slate-600 line-clamp-1" title={summary}>
                                                                         {summary}
@@ -492,44 +492,44 @@ const DashboardPage: React.FC = () => {
                                                                 <div className="grid grid-cols-1 gap-2">
                                                                     <button
                                                                         onClick={() => handleViewClick(file)}
-                                                                        className="flex items-center justify-between w-full px-3 py-2 text-sm font-semibold text-slate-700 bg-slate-50 border border-slate-200 rounded-lg hover:bg-slate-100 transition disabled:opacity-40 disabled:cursor-not-allowed"
+                                                                        className="flex items-center justify-center gap-2 w-full px-2.5 py-2 text-xs font-semibold text-slate-700 bg-slate-50 border border-slate-200 rounded-lg hover:bg-slate-100 transition disabled:opacity-40 disabled:cursor-not-allowed"
                                                                         title="مشاهده جزئیات"
                                                                         disabled={file.status === FileStatus.Processing}
                                                                     >
                                                                         <span>مشاهده</span>
-                                                                        <EyeIcon className="w-5 h-5" />
+                                                                        <EyeIcon className="w-4 h-4" />
                                                                     </button>
                                                                     <button
                                                                         onClick={() => exportCustomContentZip(file.id)}
                                                                         disabled={file.status !== FileStatus.Approved}
-                                                                        className="flex items-center justify-between w-full px-3 py-2 text-sm font-semibold text-indigo-700 bg-indigo-50 border border-indigo-100 rounded-lg hover:bg-indigo-100 transition disabled:opacity-40 disabled:cursor-not-allowed"
+                                                                        className="flex items-center justify-center gap-2 w-full px-2.5 py-2 text-xs font-semibold text-indigo-700 bg-indigo-50 border border-indigo-100 rounded-lg hover:bg-indigo-100 transition disabled:opacity-40 disabled:cursor-not-allowed"
                                                                         title="دانلود"
                                                                     >
                                                                         <span>دانلود</span>
-                                                                        <DownloadIcon className="w-5 h-5" />
+                                                                        <DownloadIcon className="w-4 h-4" />
                                                                     </button>
                                                                     <button
                                                                         onClick={() => openCancelModal(file)}
                                                                         disabled={!(file.status === FileStatus.Processing || file.status === FileStatus.Pending)}
-                                                                        className="flex items-center justify-between w-full px-3 py-2 text-sm font-semibold text-amber-700 bg-amber-50 border border-amber-200 rounded-lg hover:bg-amber-100 transition disabled:opacity-40 disabled:cursor-not-allowed"
+                                                                        className="flex items-center justify-center gap-2 w-full px-2.5 py-2 text-xs font-semibold text-amber-700 bg-amber-50 border border-amber-200 rounded-lg hover:bg-amber-100 transition disabled:opacity-40 disabled:cursor-not-allowed"
                                                                         title="توقف و حذف از صف"
                                                                     >
                                                                         <span>توقف و حذف از صف</span>
-                                                                        <StopIcon className="w-5 h-5" />
+                                                                        <StopIcon className="w-4 h-4" />
                                                                     </button>
                                                                     <button
                                                                         onClick={() => openDeleteModal(file)}
                                                                         disabled={file.status === FileStatus.Processing || file.status === FileStatus.Pending}
-                                                                        className="flex items-center justify-between w-full px-3 py-2 text-sm font-semibold text-rose-700 bg-rose-50 border border-rose-200 rounded-lg hover:bg-rose-100 transition disabled:opacity-40 disabled:cursor-not-allowed"
+                                                                        className="flex items-center justify-center gap-2 w-full px-2.5 py-2 text-xs font-semibold text-rose-700 bg-rose-50 border border-rose-200 rounded-lg hover:bg-rose-100 transition disabled:opacity-40 disabled:cursor-not-allowed"
                                                                         title="حذف آیتم"
                                                                     >
                                                                         <span>حذف</span>
-                                                                        <TrashIcon className="w-5 h-5" />
+                                                                        <TrashIcon className="w-4 h-4" />
                                                                     </button>
                                                                     {file.status === FileStatus.Pending && (
                                                                         <button
                                                                             onClick={() => togglePreview(file)}
-                                                                            className="inline-flex items-center justify-between w-full px-3 py-2 text-xs font-semibold text-indigo-700 bg-white border border-indigo-100 rounded-lg hover:bg-indigo-50 transition"
+                                                                            className="inline-flex items-center justify-center gap-2 w-full px-2.5 py-2 text-[11px] font-semibold text-indigo-700 bg-white border border-indigo-100 rounded-lg hover:bg-indigo-50 transition"
                                                                             type="button"
                                                                         >
                                                                             <span>{previewState?.expanded ? 'بستن خلاصه' : 'مشاهده خلاصه'}</span>

--- a/front/pages/DashboardPage.tsx
+++ b/front/pages/DashboardPage.tsx
@@ -424,11 +424,11 @@ const DashboardPage: React.FC = () => {
                                                         className={`bg-white border-b hover:bg-gray-50 table-row-animate transition-shadow duration-300 ${isHighlighted ? 'ring-2 ring-indigo-200 ring-offset-2 ring-offset-white bg-indigo-50/50 shadow-md new-row-highlight' : ''}`}
                                                         style={{ animationDelay: `${index * 45}ms` }}
                                                     >
-                                                        <td className="px-5 py-4 font-medium text-gray-900 whitespace-nowrap max-w-[200px]">
+                                                        <td className="px-5 py-6 font-medium text-gray-900 whitespace-nowrap max-w-[200px] align-top">
                                                             <div className="truncate" title={file.name}>{file.name}</div>
                                                             <div className="text-xs text-slate-500 mt-1">{`توسط ${file.uploader || 'ادمین'}`}</div>
                                                         </td>
-                                                        <td className="px-4 py-4 align-top w-[150px]">
+                                                        <td className="px-4 py-6 align-top w-[150px]">
                                                             <div className="space-y-1 text-[13px] text-slate-700">
                                                                 <div className="font-semibold">{date && toPersianDigits(date)}</div>
                                                                 {time && (
@@ -436,7 +436,7 @@ const DashboardPage: React.FC = () => {
                                                                 )}
                                                             </div>
                                                         </td>
-                                                        <td className="px-4 py-4 hidden md:table-cell align-top w-[120px]">
+                                                        <td className="px-4 py-6 hidden md:table-cell align-top w-[120px]">
                                                             <span
                                                                 className="inline-block font-medium text-slate-800 whitespace-nowrap leading-tight"
                                                                 style={{ fontSize: 'clamp(12px, 2.2vw, 14px)' }}
@@ -445,7 +445,7 @@ const DashboardPage: React.FC = () => {
                                                                 {file.type}
                                                             </span>
                                                         </td>
-                                                        <td className="px-4 py-4 align-top w-[170px]">
+                                                        <td className="px-4 py-6 align-top w-[170px]">
                                                             <div className="space-y-2 max-w-[170px]">
                                                                 {renderStatusBadge(file.status)}
                                                                 {file.status === FileStatus.Processing && (
@@ -482,50 +482,57 @@ const DashboardPage: React.FC = () => {
                                                                 )}
                                                             </div>
                                                         </td>
-                                                        <td className="px-4 py-4 align-top w-[190px] sticky right-0 bg-white border-l border-slate-100 shadow-[inset_1px_0_0_rgba(226,232,240,1)]">
-                                                            <div className="flex flex-col gap-3 min-w-[190px] max-w-[190px]">
+                                                        <td className="px-4 py-6 align-top w-[210px] sticky right-0 bg-white border-l border-slate-100 shadow-[inset_1px_0_0_rgba(226,232,240,1)]">
+                                                            <div className="flex flex-col gap-4 min-w-[210px] max-w-[210px]">
                                                                 {summary && (
                                                                     <p className="text-xs text-slate-600 truncate" title={summary}>
                                                                         {summary}
                                                                     </p>
                                                                 )}
-                                                                <div className="flex flex-wrap items-center gap-2 justify-start">
+                                                                <div className="flex flex-col gap-2">
                                                                     <button
                                                                         onClick={() => handleViewClick(file)}
-                                                                        className="p-1.5 text-gray-500 hover:text-indigo-600 rounded-md hover:bg-gray-100 transition disabled:opacity-30 disabled:cursor-not-allowed"
+                                                                        className="flex items-center justify-between w-full px-3 py-2 text-sm font-semibold text-slate-700 bg-slate-50 border border-slate-200 rounded-lg hover:bg-slate-100 transition disabled:opacity-40 disabled:cursor-not-allowed"
                                                                         title="مشاهده جزئیات"
                                                                         disabled={file.status === FileStatus.Processing}
                                                                     >
-                                                                        <EyeIcon className="w-5 h-5"/>
+                                                                        <span>مشاهده</span>
+                                                                        <EyeIcon className="w-5 h-5" />
                                                                     </button>
-                                                                    <button onClick={() => exportCustomContentZip(file.id)} disabled={file.status !== FileStatus.Approved} className="p-1.5 text-gray-500 hover:text-indigo-600 rounded-md hover:bg-gray-100 transition disabled:opacity-30 disabled:cursor-not-allowed" title="دانلود">
+                                                                    <button
+                                                                        onClick={() => exportCustomContentZip(file.id)}
+                                                                        disabled={file.status !== FileStatus.Approved}
+                                                                        className="flex items-center justify-between w-full px-3 py-2 text-sm font-semibold text-indigo-700 bg-indigo-50 border border-indigo-100 rounded-lg hover:bg-indigo-100 transition disabled:opacity-40 disabled:cursor-not-allowed"
+                                                                        title="دانلود"
+                                                                    >
+                                                                        <span>دانلود</span>
                                                                         <DownloadIcon className="w-5 h-5" />
                                                                     </button>
-                                                                    {(file.status === FileStatus.Processing || file.status === FileStatus.Pending) && (
-                                                                        <button
-                                                                            onClick={() => openCancelModal(file)}
-                                                                            className="p-1.5 text-amber-600 hover:text-amber-700 rounded-md hover:bg-amber-50 transition"
-                                                                            title="توقف و حذف از صف"
-                                                                        >
-                                                                            <StopIcon className="w-5 h-5" />
-                                                                        </button>
-                                                                    )}
-                                                                    {file.status !== FileStatus.Processing && file.status !== FileStatus.Pending && (
-                                                                        <button
-                                                                            onClick={() => openDeleteModal(file)}
-                                                                            className="p-1.5 text-rose-600 hover:text-rose-700 rounded-md hover:bg-rose-50 transition"
-                                                                            title="حذف آیتم"
-                                                                        >
-                                                                            <TrashIcon className="w-5 h-5" />
-                                                                        </button>
-                                                                    )}
+                                                                    <button
+                                                                        onClick={() => openCancelModal(file)}
+                                                                        disabled={!(file.status === FileStatus.Processing || file.status === FileStatus.Pending)}
+                                                                        className="flex items-center justify-between w-full px-3 py-2 text-sm font-semibold text-amber-700 bg-amber-50 border border-amber-200 rounded-lg hover:bg-amber-100 transition disabled:opacity-40 disabled:cursor-not-allowed"
+                                                                        title="توقف و حذف از صف"
+                                                                    >
+                                                                        <span>توقف و حذف از صف</span>
+                                                                        <StopIcon className="w-5 h-5" />
+                                                                    </button>
+                                                                    <button
+                                                                        onClick={() => openDeleteModal(file)}
+                                                                        disabled={file.status === FileStatus.Processing || file.status === FileStatus.Pending}
+                                                                        className="flex items-center justify-between w-full px-3 py-2 text-sm font-semibold text-rose-700 bg-rose-50 border border-rose-200 rounded-lg hover:bg-rose-100 transition disabled:opacity-40 disabled:cursor-not-allowed"
+                                                                        title="حذف آیتم"
+                                                                    >
+                                                                        <span>حذف</span>
+                                                                        <TrashIcon className="w-5 h-5" />
+                                                                    </button>
                                                                     {file.status === FileStatus.Pending && (
                                                                         <button
                                                                             onClick={() => togglePreview(file)}
-                                                                            className="inline-flex items-center gap-1 px-2 py-1 text-xs font-semibold text-indigo-700 bg-indigo-50 border border-indigo-100 rounded-lg hover:bg-indigo-100 transition"
+                                                                            className="inline-flex items-center justify-between w-full px-3 py-2 text-xs font-semibold text-indigo-700 bg-white border border-indigo-100 rounded-lg hover:bg-indigo-50 transition"
                                                                             type="button"
                                                                         >
-                                                                            {previewState?.expanded ? 'بستن خلاصه' : 'مشاهده خلاصه'}
+                                                                            <span>{previewState?.expanded ? 'بستن خلاصه' : 'مشاهده خلاصه'}</span>
                                                                             <span className={`transition-transform ${previewState?.expanded ? 'rotate-180' : ''}`}>
                                                                                 ▾
                                                                             </span>

--- a/front/pages/DashboardPage.tsx
+++ b/front/pages/DashboardPage.tsx
@@ -384,14 +384,14 @@ const DashboardPage: React.FC = () => {
                         </div>
 
                         <div className="overflow-x-auto relative">
-                            <table className="w-full text-sm text-right text-gray-600 table-auto min-w-[1100px]">
+                            <table className="w-full text-sm text-right text-gray-600 table-auto min-w-[980px]">
                                 <thead className="text-xs text-gray-700 uppercase bg-slate-50/80">
                                     <tr>
-                                        <th scope="col" className="px-6 py-3 w-[22%] min-w-[150px]">نام فایل صوتی</th>
-                                        <th scope="col" className="px-6 py-3 w-[18%] min-w-[130px]">تاریخ</th>
-                                        <th scope="col" className="px-6 py-3 hidden md:table-cell w-[12%] min-w-[100px]">نوع</th>
-                                        <th scope="col" className="px-6 py-3 w-[18%] min-w-[150px]">وضعیت</th>
-                                        <th scope="col" className="px-6 py-3 w-[30%] min-w-[240px]">اقدامات</th>
+                                        <th scope="col" className="px-6 py-3 w-[22%] min-w-[140px]">نام فایل صوتی</th>
+                                        <th scope="col" className="px-6 py-3 w-[16%] min-w-[120px]">تاریخ</th>
+                                        <th scope="col" className="px-6 py-3 hidden md:table-cell w-[12%] min-w-[90px]">نوع</th>
+                                        <th scope="col" className="px-6 py-3 w-[18%] min-w-[140px]">وضعیت</th>
+                                        <th scope="col" className="px-6 py-3 w-[32%] min-w-[220px]">اقدامات</th>
                                     </tr>
                                 </thead>
                                 <tbody>
@@ -482,14 +482,14 @@ const DashboardPage: React.FC = () => {
                                                                 )}
                                                             </div>
                                                         </td>
-                                                        <td className="px-4 py-4 align-top w-[260px] max-w-[320px] sticky right-0 bg-white border-l border-slate-100 shadow-[inset_1px_0_0_rgba(226,232,240,1),0_6px_18px_rgba(15,23,42,0.06)] z-20">
-                                                            <div className="flex flex-col gap-3 min-w-[240px]">
+                                                        <td className="px-4 py-4 align-top w-[230px] max-w-[260px] sticky right-0 bg-white border-l border-slate-100 shadow-[inset_1px_0_0_rgba(226,232,240,1),0_6px_18px_rgba(15,23,42,0.06)] z-20">
+                                                            <div className="flex flex-col gap-3 min-w-[220px]">
                                                                 {summary && (
-                                                                    <p className="text-xs text-slate-600 truncate" title={summary}>
+                                                                    <p className="text-xs text-slate-600 line-clamp-2" title={summary}>
                                                                         {summary}
                                                                     </p>
                                                                 )}
-                                                                <div className="grid grid-cols-1 sm:grid-cols-2 gap-2.5">
+                                                                <div className="grid grid-cols-1 gap-2">
                                                                     <button
                                                                         onClick={() => handleViewClick(file)}
                                                                         className="flex items-center justify-between w-full px-3 py-2 text-sm font-semibold text-slate-700 bg-slate-50 border border-slate-200 rounded-lg hover:bg-slate-100 transition disabled:opacity-40 disabled:cursor-not-allowed"

--- a/front/pages/DashboardPage.tsx
+++ b/front/pages/DashboardPage.tsx
@@ -384,14 +384,14 @@ const DashboardPage: React.FC = () => {
                         </div>
 
                         <div className="overflow-x-auto relative">
-                            <table className="w-full text-sm text-right text-gray-600 table-auto min-w-[880px]">
+                            <table className="w-full text-sm text-right text-gray-600 table-auto min-w-[820px]">
                                 <thead className="text-xs text-gray-700 uppercase bg-slate-50/80">
                                     <tr>
-                                        <th scope="col" className="px-6 py-3 w-[20%] min-w-[140px]">نام فایل صوتی</th>
-                                        <th scope="col" className="px-6 py-3 w-[14%] min-w-[110px]">تاریخ</th>
-                                        <th scope="col" className="px-6 py-3 hidden md:table-cell w-[10%] min-w-[80px]">نوع</th>
-                                        <th scope="col" className="px-6 py-3 w-[16%] min-w-[120px]">وضعیت</th>
-                                        <th scope="col" className="px-6 py-3 w-[30%] min-w-[210px]">اقدامات</th>
+                                        <th scope="col" className="px-6 py-3 w-[18%] min-w-[130px]">نام فایل صوتی</th>
+                                        <th scope="col" className="px-6 py-3 w-[12%] min-w-[95px]">تاریخ</th>
+                                        <th scope="col" className="px-6 py-3 hidden md:table-cell w-[8%] min-w-[70px]">نوع</th>
+                                        <th scope="col" className="px-6 py-3 w-[14%] min-w-[110px]">وضعیت</th>
+                                        <th scope="col" className="px-6 py-3 w-[28%] min-w-[210px]">اقدامات</th>
                                     </tr>
                                 </thead>
                                 <tbody>
@@ -424,11 +424,11 @@ const DashboardPage: React.FC = () => {
                                                         className={`bg-white border-b hover:bg-gray-50 table-row-animate transition-shadow duration-300 ${isHighlighted ? 'ring-2 ring-indigo-200 ring-offset-2 ring-offset-white bg-indigo-50/50 shadow-md new-row-highlight' : ''}`}
                                                         style={{ animationDelay: `${index * 45}ms` }}
                                                     >
-                                                        <td className="px-5 py-4 font-medium text-gray-900 whitespace-nowrap max-w-[180px] align-top">
+                                                        <td className="px-5 py-4 font-medium text-gray-900 whitespace-nowrap max-w-[160px] align-top">
                                                             <div className="truncate" title={file.name}>{file.name}</div>
                                                             <div className="text-xs text-slate-500 mt-1">{`توسط ${file.uploader || 'ادمین'}`}</div>
                                                         </td>
-                                                        <td className="px-4 py-4 align-top w-[150px]">
+                                                        <td className="px-4 py-4 align-top w-[130px]">
                                                             <div className="space-y-1 text-[13px] text-slate-700">
                                                                 <div className="font-semibold">{date && toPersianDigits(date)}</div>
                                                                 {time && (
@@ -436,7 +436,7 @@ const DashboardPage: React.FC = () => {
                                                                 )}
                                                             </div>
                                                         </td>
-                                                        <td className="px-4 py-4 hidden md:table-cell align-top w-[110px]">
+                                                        <td className="px-4 py-4 hidden md:table-cell align-top w-[95px]">
                                                             <span
                                                                 className="inline-block font-medium text-slate-800 whitespace-nowrap leading-tight"
                                                                 style={{ fontSize: 'clamp(12px, 2.2vw, 14px)' }}
@@ -445,8 +445,8 @@ const DashboardPage: React.FC = () => {
                                                                 {file.type}
                                                             </span>
                                                         </td>
-                                                        <td className="px-4 py-4 align-top w-[150px]">
-                                                            <div className="space-y-2 max-w-[150px]">
+                                                        <td className="px-4 py-4 align-top w-[130px]">
+                                                            <div className="space-y-2 max-w-[130px]">
                                                                 {renderStatusBadge(file.status)}
                                                                 {file.status === FileStatus.Processing && (
                                                                     <div className="space-y-1">
@@ -482,8 +482,8 @@ const DashboardPage: React.FC = () => {
                                                                 )}
                                                             </div>
                                                         </td>
-                                                        <td className="px-3 py-4 align-top w-[210px] max-w-[210px] min-w-[210px] sticky right-0 bg-white border-l border-slate-100 shadow-[inset_1px_0_0_rgba(226,232,240,1),0_6px_18px_rgba(15,23,42,0.06)] z-20">
-                                                            <div className="flex flex-col gap-2.5 min-w-[210px]">
+                                                        <td className="px-3 py-4 align-top w-[210px] max-w-[210px] min-w-[205px] sticky right-0 bg-white border-l border-slate-100 shadow-[inset_1px_0_0_rgba(226,232,240,1),0_6px_18px_rgba(15,23,42,0.06)] z-20">
+                                                            <div className="flex flex-col gap-2.5 min-w-[205px]">
                                                                 {summary && (
                                                                     <p className="text-[11px] text-slate-600 line-clamp-1" title={summary}>
                                                                         {summary}

--- a/front/pages/DashboardPage.tsx
+++ b/front/pages/DashboardPage.tsx
@@ -482,54 +482,54 @@ const DashboardPage: React.FC = () => {
                                                                 )}
                                                             </div>
                                                         </td>
-                                                        <td className="px-3 py-4 align-top w-[185px] max-w-[190px] sticky right-0 bg-white border-l border-slate-100 shadow-[inset_1px_0_0_rgba(226,232,240,1),0_6px_18px_rgba(15,23,42,0.06)] z-20">
-                                                            <div className="flex flex-col gap-3 min-w-[185px]">
+                                                        <td className="px-3 py-4 align-top w-[210px] max-w-[210px] min-w-[210px] sticky right-0 bg-white border-l border-slate-100 shadow-[inset_1px_0_0_rgba(226,232,240,1),0_6px_18px_rgba(15,23,42,0.06)] z-20">
+                                                            <div className="flex flex-col gap-2.5 min-w-[210px]">
                                                                 {summary && (
-                                                                    <p className="text-xs text-slate-600 line-clamp-1" title={summary}>
+                                                                    <p className="text-[11px] text-slate-600 line-clamp-1" title={summary}>
                                                                         {summary}
                                                                     </p>
                                                                 )}
-                                                                <div className="grid grid-cols-1 gap-2">
+                                                                <div className="grid grid-cols-1 gap-1.5">
                                                                     <button
                                                                         onClick={() => handleViewClick(file)}
-                                                                        className="flex items-center justify-center gap-2 w-full px-2.5 py-2 text-xs font-semibold text-slate-700 bg-slate-50 border border-slate-200 rounded-lg hover:bg-slate-100 transition disabled:opacity-40 disabled:cursor-not-allowed"
+                                                                        className="flex items-center justify-center gap-1.5 w-full px-2 py-1.5 text-[11px] font-semibold text-slate-700 bg-slate-50 border border-slate-200 rounded-lg hover:bg-slate-100 transition disabled:opacity-40 disabled:cursor-not-allowed leading-tight"
                                                                         title="مشاهده جزئیات"
                                                                         disabled={file.status === FileStatus.Processing}
                                                                     >
                                                                         <span>مشاهده</span>
-                                                                        <EyeIcon className="w-4 h-4" />
+                                                                        <EyeIcon className="w-3.5 h-3.5" />
                                                                     </button>
                                                                     <button
                                                                         onClick={() => exportCustomContentZip(file.id)}
                                                                         disabled={file.status !== FileStatus.Approved}
-                                                                        className="flex items-center justify-center gap-2 w-full px-2.5 py-2 text-xs font-semibold text-indigo-700 bg-indigo-50 border border-indigo-100 rounded-lg hover:bg-indigo-100 transition disabled:opacity-40 disabled:cursor-not-allowed"
+                                                                        className="flex items-center justify-center gap-1.5 w-full px-2 py-1.5 text-[11px] font-semibold text-indigo-700 bg-indigo-50 border border-indigo-100 rounded-lg hover:bg-indigo-100 transition disabled:opacity-40 disabled:cursor-not-allowed leading-tight"
                                                                         title="دانلود"
                                                                     >
                                                                         <span>دانلود</span>
-                                                                        <DownloadIcon className="w-4 h-4" />
+                                                                        <DownloadIcon className="w-3.5 h-3.5" />
                                                                     </button>
                                                                     <button
                                                                         onClick={() => openCancelModal(file)}
                                                                         disabled={!(file.status === FileStatus.Processing || file.status === FileStatus.Pending)}
-                                                                        className="flex items-center justify-center gap-2 w-full px-2.5 py-2 text-xs font-semibold text-amber-700 bg-amber-50 border border-amber-200 rounded-lg hover:bg-amber-100 transition disabled:opacity-40 disabled:cursor-not-allowed"
+                                                                        className="flex items-center justify-center gap-1.5 w-full px-2 py-1.5 text-[11px] font-semibold text-amber-700 bg-amber-50 border border-amber-200 rounded-lg hover:bg-amber-100 transition disabled:opacity-40 disabled:cursor-not-allowed leading-tight"
                                                                         title="توقف و حذف از صف"
                                                                     >
                                                                         <span>توقف و حذف از صف</span>
-                                                                        <StopIcon className="w-4 h-4" />
+                                                                        <StopIcon className="w-3.5 h-3.5" />
                                                                     </button>
                                                                     <button
                                                                         onClick={() => openDeleteModal(file)}
                                                                         disabled={file.status === FileStatus.Processing || file.status === FileStatus.Pending}
-                                                                        className="flex items-center justify-center gap-2 w-full px-2.5 py-2 text-xs font-semibold text-rose-700 bg-rose-50 border border-rose-200 rounded-lg hover:bg-rose-100 transition disabled:opacity-40 disabled:cursor-not-allowed"
+                                                                        className="flex items-center justify-center gap-1.5 w-full px-2 py-1.5 text-[11px] font-semibold text-rose-700 bg-rose-50 border border-rose-200 rounded-lg hover:bg-rose-100 transition disabled:opacity-40 disabled:cursor-not-allowed leading-tight"
                                                                         title="حذف آیتم"
                                                                     >
                                                                         <span>حذف</span>
-                                                                        <TrashIcon className="w-4 h-4" />
+                                                                        <TrashIcon className="w-3.5 h-3.5" />
                                                                     </button>
                                                                     {file.status === FileStatus.Pending && (
                                                                         <button
                                                                             onClick={() => togglePreview(file)}
-                                                                            className="inline-flex items-center justify-center gap-2 w-full px-2.5 py-2 text-[11px] font-semibold text-indigo-700 bg-white border border-indigo-100 rounded-lg hover:bg-indigo-50 transition"
+                                                                            className="inline-flex items-center justify-center gap-1.5 w-full px-2 py-1.5 text-[11px] font-semibold text-indigo-700 bg-white border border-indigo-100 rounded-lg hover:bg-indigo-50 transition leading-tight"
                                                                             type="button"
                                                                         >
                                                                             <span>{previewState?.expanded ? 'بستن خلاصه' : 'مشاهده خلاصه'}</span>

--- a/front/pages/DashboardPage.tsx
+++ b/front/pages/DashboardPage.tsx
@@ -384,14 +384,14 @@ const DashboardPage: React.FC = () => {
                         </div>
 
                         <div className="overflow-x-auto relative">
-                            <table className="w-full text-sm text-right text-gray-600 table-auto min-w-[980px]">
+                            <table className="w-full text-sm text-right text-gray-600 table-auto min-w-[880px]">
                                 <thead className="text-xs text-gray-700 uppercase bg-slate-50/80">
                                     <tr>
-                                        <th scope="col" className="px-6 py-3 w-[22%] min-w-[140px]">نام فایل صوتی</th>
-                                        <th scope="col" className="px-6 py-3 w-[16%] min-w-[120px]">تاریخ</th>
-                                        <th scope="col" className="px-6 py-3 hidden md:table-cell w-[12%] min-w-[90px]">نوع</th>
-                                        <th scope="col" className="px-6 py-3 w-[18%] min-w-[140px]">وضعیت</th>
-                                        <th scope="col" className="px-6 py-3 w-[32%] min-w-[220px]">اقدامات</th>
+                                        <th scope="col" className="px-6 py-3 w-[20%] min-w-[140px]">نام فایل صوتی</th>
+                                        <th scope="col" className="px-6 py-3 w-[14%] min-w-[110px]">تاریخ</th>
+                                        <th scope="col" className="px-6 py-3 hidden md:table-cell w-[10%] min-w-[80px]">نوع</th>
+                                        <th scope="col" className="px-6 py-3 w-[16%] min-w-[120px]">وضعیت</th>
+                                        <th scope="col" className="px-6 py-3 w-[30%] min-w-[210px]">اقدامات</th>
                                     </tr>
                                 </thead>
                                 <tbody>
@@ -424,7 +424,7 @@ const DashboardPage: React.FC = () => {
                                                         className={`bg-white border-b hover:bg-gray-50 table-row-animate transition-shadow duration-300 ${isHighlighted ? 'ring-2 ring-indigo-200 ring-offset-2 ring-offset-white bg-indigo-50/50 shadow-md new-row-highlight' : ''}`}
                                                         style={{ animationDelay: `${index * 45}ms` }}
                                                     >
-                                                        <td className="px-5 py-4 font-medium text-gray-900 whitespace-nowrap max-w-[200px] align-top">
+                                                        <td className="px-5 py-4 font-medium text-gray-900 whitespace-nowrap max-w-[180px] align-top">
                                                             <div className="truncate" title={file.name}>{file.name}</div>
                                                             <div className="text-xs text-slate-500 mt-1">{`توسط ${file.uploader || 'ادمین'}`}</div>
                                                         </td>
@@ -436,7 +436,7 @@ const DashboardPage: React.FC = () => {
                                                                 )}
                                                             </div>
                                                         </td>
-                                                        <td className="px-4 py-4 hidden md:table-cell align-top w-[120px]">
+                                                        <td className="px-4 py-4 hidden md:table-cell align-top w-[110px]">
                                                             <span
                                                                 className="inline-block font-medium text-slate-800 whitespace-nowrap leading-tight"
                                                                 style={{ fontSize: 'clamp(12px, 2.2vw, 14px)' }}
@@ -445,8 +445,8 @@ const DashboardPage: React.FC = () => {
                                                                 {file.type}
                                                             </span>
                                                         </td>
-                                                        <td className="px-4 py-4 align-top w-[170px]">
-                                                            <div className="space-y-2 max-w-[170px]">
+                                                        <td className="px-4 py-4 align-top w-[150px]">
+                                                            <div className="space-y-2 max-w-[150px]">
                                                                 {renderStatusBadge(file.status)}
                                                                 {file.status === FileStatus.Processing && (
                                                                     <div className="space-y-1">
@@ -482,10 +482,10 @@ const DashboardPage: React.FC = () => {
                                                                 )}
                                                             </div>
                                                         </td>
-                                                        <td className="px-4 py-4 align-top w-[230px] max-w-[260px] sticky right-0 bg-white border-l border-slate-100 shadow-[inset_1px_0_0_rgba(226,232,240,1),0_6px_18px_rgba(15,23,42,0.06)] z-20">
-                                                            <div className="flex flex-col gap-3 min-w-[220px]">
+                                                        <td className="px-3 py-4 align-top w-[210px] max-w-[220px] sticky right-0 bg-white border-l border-slate-100 shadow-[inset_1px_0_0_rgba(226,232,240,1),0_6px_18px_rgba(15,23,42,0.06)] z-20">
+                                                            <div className="flex flex-col gap-3 min-w-[210px]">
                                                                 {summary && (
-                                                                    <p className="text-xs text-slate-600 line-clamp-2" title={summary}>
+                                                                    <p className="text-xs text-slate-600 line-clamp-1" title={summary}>
                                                                         {summary}
                                                                     </p>
                                                                 )}

--- a/front/pages/DashboardPage.tsx
+++ b/front/pages/DashboardPage.tsx
@@ -384,14 +384,14 @@ const DashboardPage: React.FC = () => {
                         </div>
 
                         <div className="overflow-x-auto">
-                            <table className="w-full min-w-[980px] text-sm text-right text-gray-600">
+                            <table className="w-full text-sm text-right text-gray-600 table-fixed">
                                 <thead className="text-xs text-gray-700 uppercase bg-slate-50/80">
                                     <tr>
-                                        <th scope="col" className="px-6 py-3 min-w-[200px]">نام فایل صوتی</th>
-                                        <th scope="col" className="px-6 py-3 min-w-[170px]">تاریخ</th>
-                                        <th scope="col" className="px-6 py-3 hidden md:table-cell min-w-[120px]">نوع</th>
-                                        <th scope="col" className="px-6 py-3 min-w-[210px]">وضعیت</th>
-                                        <th scope="col" className="px-6 py-3 min-w-[220px]">اقدامات</th>
+                                        <th scope="col" className="px-6 py-3 w-[26%] min-w-[160px]">نام فایل صوتی</th>
+                                        <th scope="col" className="px-6 py-3 w-[18%] min-w-[140px]">تاریخ</th>
+                                        <th scope="col" className="px-6 py-3 hidden md:table-cell w-[14%] min-w-[110px]">نوع</th>
+                                        <th scope="col" className="px-6 py-3 w-[18%] min-w-[150px]">وضعیت</th>
+                                        <th scope="col" className="px-6 py-3 w-[24%] min-w-[190px]">اقدامات</th>
                                     </tr>
                                 </thead>
                                 <tbody>
@@ -482,14 +482,14 @@ const DashboardPage: React.FC = () => {
                                                                 )}
                                                             </div>
                                                         </td>
-                                                        <td className="px-4 py-4 align-top w-[210px] sticky right-0 bg-white border-l border-slate-100 shadow-[inset_1px_0_0_rgba(226,232,240,1)] z-10">
-                                                            <div className="flex flex-col gap-3 min-w-[210px] max-w-[210px]">
+                                                        <td className="px-4 py-4 align-top w-[220px] sticky right-0 bg-white border-l border-slate-100 shadow-[inset_1px_0_0_rgba(226,232,240,1)] z-10">
+                                                            <div className="flex flex-col gap-3 min-w-[200px]">
                                                                 {summary && (
                                                                     <p className="text-xs text-slate-600 truncate" title={summary}>
                                                                         {summary}
                                                                     </p>
                                                                 )}
-                                                                <div className="flex flex-col gap-2.5">
+                                                                <div className="grid grid-cols-1 sm:grid-cols-2 gap-2.5">
                                                                     <button
                                                                         onClick={() => handleViewClick(file)}
                                                                         className="flex items-center justify-between w-full px-3 py-2 text-sm font-semibold text-slate-700 bg-slate-50 border border-slate-200 rounded-lg hover:bg-slate-100 transition disabled:opacity-40 disabled:cursor-not-allowed"

--- a/front/pages/DashboardPage.tsx
+++ b/front/pages/DashboardPage.tsx
@@ -383,15 +383,15 @@ const DashboardPage: React.FC = () => {
                             </button>
                         </div>
 
-                        <div className="overflow-x-auto">
-                            <table className="w-full text-sm text-right text-gray-600 table-fixed">
+                        <div className="overflow-x-auto relative">
+                            <table className="w-full text-sm text-right text-gray-600 table-auto min-w-[1100px]">
                                 <thead className="text-xs text-gray-700 uppercase bg-slate-50/80">
                                     <tr>
-                                        <th scope="col" className="px-6 py-3 w-[26%] min-w-[160px]">نام فایل صوتی</th>
-                                        <th scope="col" className="px-6 py-3 w-[18%] min-w-[140px]">تاریخ</th>
-                                        <th scope="col" className="px-6 py-3 hidden md:table-cell w-[14%] min-w-[110px]">نوع</th>
+                                        <th scope="col" className="px-6 py-3 w-[22%] min-w-[150px]">نام فایل صوتی</th>
+                                        <th scope="col" className="px-6 py-3 w-[18%] min-w-[130px]">تاریخ</th>
+                                        <th scope="col" className="px-6 py-3 hidden md:table-cell w-[12%] min-w-[100px]">نوع</th>
                                         <th scope="col" className="px-6 py-3 w-[18%] min-w-[150px]">وضعیت</th>
-                                        <th scope="col" className="px-6 py-3 w-[24%] min-w-[190px]">اقدامات</th>
+                                        <th scope="col" className="px-6 py-3 w-[30%] min-w-[240px]">اقدامات</th>
                                     </tr>
                                 </thead>
                                 <tbody>
@@ -482,8 +482,8 @@ const DashboardPage: React.FC = () => {
                                                                 )}
                                                             </div>
                                                         </td>
-                                                        <td className="px-4 py-4 align-top w-[220px] sticky right-0 bg-white border-l border-slate-100 shadow-[inset_1px_0_0_rgba(226,232,240,1)] z-10">
-                                                            <div className="flex flex-col gap-3 min-w-[200px]">
+                                                        <td className="px-4 py-4 align-top w-[260px] max-w-[320px] sticky right-0 bg-white border-l border-slate-100 shadow-[inset_1px_0_0_rgba(226,232,240,1),0_6px_18px_rgba(15,23,42,0.06)] z-20">
+                                                            <div className="flex flex-col gap-3 min-w-[240px]">
                                                                 {summary && (
                                                                     <p className="text-xs text-slate-600 truncate" title={summary}>
                                                                         {summary}

--- a/front/pages/DashboardPage.tsx
+++ b/front/pages/DashboardPage.tsx
@@ -424,11 +424,11 @@ const DashboardPage: React.FC = () => {
                                                         className={`bg-white border-b hover:bg-gray-50 table-row-animate transition-shadow duration-300 ${isHighlighted ? 'ring-2 ring-indigo-200 ring-offset-2 ring-offset-white bg-indigo-50/50 shadow-md new-row-highlight' : ''}`}
                                                         style={{ animationDelay: `${index * 45}ms` }}
                                                     >
-                                                        <td className="px-5 py-6 font-medium text-gray-900 whitespace-nowrap max-w-[200px] align-top">
+                                                        <td className="px-5 py-4 font-medium text-gray-900 whitespace-nowrap max-w-[200px] align-top">
                                                             <div className="truncate" title={file.name}>{file.name}</div>
                                                             <div className="text-xs text-slate-500 mt-1">{`توسط ${file.uploader || 'ادمین'}`}</div>
                                                         </td>
-                                                        <td className="px-4 py-6 align-top w-[150px]">
+                                                        <td className="px-4 py-4 align-top w-[150px]">
                                                             <div className="space-y-1 text-[13px] text-slate-700">
                                                                 <div className="font-semibold">{date && toPersianDigits(date)}</div>
                                                                 {time && (
@@ -436,7 +436,7 @@ const DashboardPage: React.FC = () => {
                                                                 )}
                                                             </div>
                                                         </td>
-                                                        <td className="px-4 py-6 hidden md:table-cell align-top w-[120px]">
+                                                        <td className="px-4 py-4 hidden md:table-cell align-top w-[120px]">
                                                             <span
                                                                 className="inline-block font-medium text-slate-800 whitespace-nowrap leading-tight"
                                                                 style={{ fontSize: 'clamp(12px, 2.2vw, 14px)' }}
@@ -445,7 +445,7 @@ const DashboardPage: React.FC = () => {
                                                                 {file.type}
                                                             </span>
                                                         </td>
-                                                        <td className="px-4 py-6 align-top w-[170px]">
+                                                        <td className="px-4 py-4 align-top w-[170px]">
                                                             <div className="space-y-2 max-w-[170px]">
                                                                 {renderStatusBadge(file.status)}
                                                                 {file.status === FileStatus.Processing && (
@@ -482,14 +482,14 @@ const DashboardPage: React.FC = () => {
                                                                 )}
                                                             </div>
                                                         </td>
-                                                        <td className="px-4 py-6 align-top w-[210px] sticky right-0 bg-white border-l border-slate-100 shadow-[inset_1px_0_0_rgba(226,232,240,1)]">
-                                                            <div className="flex flex-col gap-4 min-w-[210px] max-w-[210px]">
+                                                        <td className="px-4 py-4 align-top w-[210px] sticky right-0 bg-white border-l border-slate-100 shadow-[inset_1px_0_0_rgba(226,232,240,1)] z-10">
+                                                            <div className="flex flex-col gap-3 min-w-[210px] max-w-[210px]">
                                                                 {summary && (
                                                                     <p className="text-xs text-slate-600 truncate" title={summary}>
                                                                         {summary}
                                                                     </p>
                                                                 )}
-                                                                <div className="flex flex-col gap-2">
+                                                                <div className="flex flex-col gap-2.5">
                                                                     <button
                                                                         onClick={() => handleViewClick(file)}
                                                                         className="flex items-center justify-between w-full px-3 py-2 text-sm font-semibold text-slate-700 bg-slate-50 border border-slate-200 rounded-lg hover:bg-slate-100 transition disabled:opacity-40 disabled:cursor-not-allowed"


### PR DESCRIPTION
## Summary
- increase audio list row padding for better spacing
- stack key action buttons vertically and keep them visible with state-aware disabling

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931bcd7ea94832785dd299f4d49422f)